### PR TITLE
Library: Arrays: comment out unused method to fix compiler error

### DIFF
--- a/src/Library/src/Arrays.cpp
+++ b/src/Library/src/Arrays.cpp
@@ -142,10 +142,12 @@ namespace {
       return stream.iword(i);
   }
 
+#if 0
   long& is_text(std::ios_base& stream) {
       static const int i = std::ios_base::xalloc();
       return stream.iword(i);
   }
+#endif
 
   long& zero_level_set(std::ios_base& stream) {
       static const int i = std::ios_base::xalloc();


### PR DESCRIPTION
The build was failing with:
src/Arrays.cpp:145:9: error: 'long int& {anonymous}::is_text(std::ios_base&)' defined but not used [-Werror=unused-function]
   long& is_text(std::ios_base& stream) {
         ^
cc1plus: all warnings being treated as errors