### PR TITLE
build: Use the correct variable for automake flags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,4 +5,4 @@ SUBDIRS = src
 
 EXTRA_DIST = autogen.sh
 
-ACLOCAL_FLAGS = -I m4
+ACLOCAL_AMFLAGS = -I m4


### PR DESCRIPTION
Current autotools would warn about it otherwise

This change can be used as who represents BBC in managing this project deems fit licensing wise.
