### PR TITLE
Improve checking of higher quantisers

### DIFF
--- a/src/EncodeHQ-CBR/EncodeHQ-CBR.cpp
+++ b/src/EncodeHQ-CBR/EncodeHQ-CBR.cpp
@@ -111,7 +111,7 @@ const Array2D quantIndices(const Picture& coefficients,
           deltaYSS = trialYSS - prevYSS;
           prevYSS = trialYSS;
         } while (deltaYSS <0);
-        q = --trialQ;
+        q = trialQ - 1;
       }
       indices[row][column] = q;
     }

--- a/src/EncodeHQ-CBR/EncodeHQ-CBR.cpp
+++ b/src/EncodeHQ-CBR/EncodeHQ-CBR.cpp
@@ -100,16 +100,18 @@ const Array2D quantIndices(const Picture& coefficients,
         }
       }
       // Now try a few higher quantisers and check residual values
+      // Keeps going until residual stops improving
       {
         trialQ = q;
-        long long YSS = yss_for_slice(slices[row][column], trialQ, qMatrix);
+        long long prevYSS = yss_for_slice(slices[row][column], trialQ, qMatrix);
+        long long deltaYSS;
         do {
           trialQ++;
           long long trialYSS = yss_for_slice(slices[row][column], trialQ, qMatrix);
-          if (trialYSS > YSS)
-            break;
-          q = trialQ;
-        } while (true);
+          deltaYSS = trialYSS - prevYSS;
+          prevYSS = trialYSS;
+        } while (deltaYSS <0);
+        q = --trialQ;
       }
       indices[row][column] = q;
     }

--- a/src/Library/src/Quantisation.cpp
+++ b/src/Library/src/Quantisation.cpp
@@ -58,6 +58,7 @@ const int quant_factor(int q) {
 //  0x100000000, 0x1306FE0A3, 0x16A09E668, 0x1AE89F996, 0x200000000, 0x260DFC146, 0x2D413CCD0, 0x35D13F32B
   };
   if (q<0) q=0;
+  if (q>120) q=120;
   return static_cast<int>(lookup[q]);
 }
 

--- a/src/Library/src/Quantisation.cpp
+++ b/src/Library/src/Quantisation.cpp
@@ -58,7 +58,7 @@ const int quant_factor(int q) {
 //  0x100000000, 0x1306FE0A3, 0x16A09E668, 0x1AE89F996, 0x200000000, 0x260DFC146, 0x2D413CCD0, 0x35D13F32B
   };
   if (q<0) q=0;
-  if (q>120) q=120;
+  if (q>119) q=119;
   return static_cast<int>(lookup[q]);
 }
 

--- a/src/Library/src/Quantisation.cpp
+++ b/src/Library/src/Quantisation.cpp
@@ -39,10 +39,6 @@ const Array2D adjust_quant_indices(const Array2D& qIndices, const int qMatrix) {
 
 const int quant_factor(int q) {
   // Lookup table valid q<120. For q>= 120 quant_factor(q) requires more than 32 bits.
-  if (q>119) {
-    throw std::logic_error("quantization index exceeds 119, corresponding quantization factor exceeds 32 bits.");
-	  return EXIT_FAILURE;
-  }
   static const unsigned int lookup[120] = {
     0x000000004, 0x000000005, 0x000000006, 0x000000007, 0x000000008, 0x00000000A, 0x00000000B, 0x00000000D,
     0x000000010, 0x000000013, 0x000000017, 0x00000001B, 0x000000020, 0x000000026, 0x00000002D, 0x000000036,
@@ -61,6 +57,10 @@ const int quant_factor(int q) {
     0x040000000, 0x04C1BF829, 0x05A82799A, 0x06BA27E65, 0x080000000, 0x09837F052, 0x0B504F334, 0x0D744FCCB,
 //  0x100000000, 0x1306FE0A3, 0x16A09E668, 0x1AE89F996, 0x200000000, 0x260DFC146, 0x2D413CCD0, 0x35D13F32B
   };
+  if (q > (int)(sizeof(lookup) / sizeof(lookup[0]) - 1 )) {
+    throw std::logic_error("quantization index exceeds maximum implemented value.");
+	  return EXIT_FAILURE;
+  }
   if (q<0) q=0;
   return static_cast<int>(lookup[q]);
 }

--- a/src/Library/src/Quantisation.cpp
+++ b/src/Library/src/Quantisation.cpp
@@ -39,6 +39,10 @@ const Array2D adjust_quant_indices(const Array2D& qIndices, const int qMatrix) {
 
 const int quant_factor(int q) {
   // Lookup table valid q<120. For q>= 120 quant_factor(q) requires more than 32 bits.
+  if (q>119) {
+    throw std::logic_error("quantization index exceeds 119, corresponding quantization factor exceeds 32 bits.");
+	  return EXIT_FAILURE;
+  }
   static const unsigned int lookup[120] = {
     0x000000004, 0x000000005, 0x000000006, 0x000000007, 0x000000008, 0x00000000A, 0x00000000B, 0x00000000D,
     0x000000010, 0x000000013, 0x000000017, 0x00000001B, 0x000000020, 0x000000026, 0x00000002D, 0x000000036,
@@ -58,7 +62,6 @@ const int quant_factor(int q) {
 //  0x100000000, 0x1306FE0A3, 0x16A09E668, 0x1AE89F996, 0x200000000, 0x260DFC146, 0x2D413CCD0, 0x35D13F32B
   };
   if (q<0) q=0;
-  if (q>119) q=119;
   return static_cast<int>(lookup[q]);
 }
 


### PR DESCRIPTION
Fixes #10 and fixes #17  

Previously, the checking of higher quantisers would increment q and select the value before the residual was worse than for the smallest possible q. This led to an infinite loop for slices with only zeros, as the residual stayed constant (also at zero). When q incremented beyond 119, the lookup when determining the quantization factor would read off the end of the array. Eventually empty memory would be reached and a division by zero occured, resulting in the error.

Now, the checking of higher quantisers continues as long as there is an improvement in the residual against the previously checked q. If the residual stays constant or gets worse, the checking terminates and the previous q value is used. This prevents the infinite loop when only zeros are present.

Additionally, an error is now thrown if the lookup attempts to read past the end of the array.