### PR TITLE
Stops exit on sequence end and handles eof

### DIFF
--- a/src/DecodeStream/DecodeStream.cpp
+++ b/src/DecodeStream/DecodeStream.cpp
@@ -202,9 +202,13 @@ try { //Giant try block around all code to get error messages
 
   while (true) {
     // Read data unit from stream
-    if (!inStream) {
-      // TODO: Add proper handling
-      break;
+    if (inStream.eof()) {
+      clog << "End of data stream reached successfully, exiting." << endl;
+      return EXIT_SUCCESS;
+    }
+    else if(inStream.fail()){
+      clog << "An error has occured in the data stream, exiting." << endl;
+      return EXIT_FAILURE;
     }
 
     DataUnit du;
@@ -250,9 +254,9 @@ try { //Giant try block around all code to get error messages
       break;
     case END_OF_SEQUENCE:
       if (verbose) {
-        clog << "End of Sequence after " << frame << " frames, exiting" << endl;
+        clog << "End of Sequence after " << frame << " frames" << endl;
       }
-      return EXIT_SUCCESS;
+      break;
     case LD_PICTURE:
       {
         if (verbose) clog << "Parsing Picture Header" << endl;
@@ -956,7 +960,6 @@ catch (const std::exception& ex) {
     cout << "Error: " << ex.what() << endl;
     return EXIT_FAILURE;
 }
-
   // Program should never reach here!
   return EXIT_FAILURE;
 }


### PR DESCRIPTION
Fixes #14  

Simple fix to erroneously finishing at the end of a sequence by removing return. 

Tidies up the input stream handling so that the stream end is caught and the processing finishes in an appropriate place.