### PR TITLE
Minor build fix

### DIFF
--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -161,7 +161,7 @@ if test "x$want_boost" = "xyes"; then
         AC_MSG_RESULT(yes)
     succeeded=yes
     found_system=yes
-        ],[
+        ],[:
         ])
     AC_LANG_POP([C++])
 
@@ -244,7 +244,7 @@ if test "x$want_boost" = "xyes"; then
             AC_MSG_RESULT(yes)
         succeeded=yes
         found_system=yes
-            ],[
+            ],[:
             ])
         AC_LANG_POP([C++])
     fi


### PR DESCRIPTION
Fixes #24 

Adds colons to ax_boost_base.m4

These colons are placed in previously empty else clauses in 'configure'. They do nothing, but prevent the build from failing with an empty else clause.