### PR TITLE
Pass correct arguments to stream format function call

### DIFF
--- a/src/EncodeHQ-ConstQ/EncodeHQ-ConstQ.cpp
+++ b/src/EncodeHQ-ConstQ/EncodeHQ-ConstQ.cpp
@@ -336,7 +336,7 @@ try { //Giant try block around all code to get error messages
 
         //Write packaged output
         if (verbose) clog << "Writing compressed output to file" << endl;
-        outStream << dataunitio::highQualityVBR(sliceScalar, sliceScalar); // Write output in HQ VBR mode
+        outStream << dataunitio::highQualityVBR(slicePrefix, sliceScalar); // Write output in HQ VBR mode
         outStream << outWrapped;
         if (!outStream) {
           cerr << "Failed to write output file \"" << outFileName << "\"" << endl;


### PR DESCRIPTION
Closes #9 

Straightforward fix for a problem that took a while to track down.

When the scalar and prefix arguments were the same, no error was observed.

In the example command in #9 slicePrefix and sliceScalar should have been 0 and 1 respectively. This bug introduced an erroneous empty byte at the start of the wavelet transform data.

I've also opened #27 to address the annoying diffs arising from the mixed line endings in the repository.