### PR TITLE
18 increase quantisation index limit

### DIFF
--- a/src/EncodeHQ-ConstQ/EncodeParams.cpp
+++ b/src/EncodeHQ-ConstQ/EncodeParams.cpp
@@ -1,10 +1,10 @@
 /*********************************************************************/
 /* EncodeParams.cpp                                                  */
-/* Author: Tim Borer,  BBC Research                                  */
-/* This version 19th September 2013                                  */
+/* Author: Tim Borer and Galen Reich,  BBC Research & Development    */
+/* This version July 2020                                            */
 /*                                                                   */
 /* Defines getting program parameters from command line.             */
-/* Copyright (c) BBC 2011-2015 -- For license see the LICENSE file   */
+/* Copyright (c) BBC 2011-2020 -- For license see the LICENSE file   */
 /*********************************************************************/
 
 #include "EncodeParams.h"


### PR DESCRIPTION
Closes #18 

For the HQ-ConstQ encoder the quantisation index should have been limited at 119 (corresponding to the existing error message "quantisation index must be in the range 0 to 119"), but was instead limited at 63. 

This pull request increases this limit to 119.