### PR TITLE
Throw helpful error if the size of a component slice won't fit in 1 byte

### DIFF
--- a/src/Library/src/Slices.cpp
+++ b/src/Library/src/Slices.cpp
@@ -111,7 +111,11 @@ const int component_slice_bytes(const Array2D& slice, const char waveletDepth, c
       }
     }
   }
-  return (((count+7)/8 + scalar - 1)/scalar)*scalar; // return whole number of scalar byte units
+  int scaled_slice_length = ((count+7)/8 + scalar - 1)/scalar;
+  if (scaled_slice_length > 0xFF){
+    throw std::logic_error("Slice scalar is too small, consider using a larger slice scalar.");
+  }
+  return scaled_slice_length*scalar; // return whole number of scalar byte units
 }
 
 SliceQuantiser::SliceQuantiser(const Array2D& coefficients,


### PR DESCRIPTION
Closes #8 

The size of a single slice component is represented in a single byte that preceeds the coding of that component. This adds a check to ensure that the slice component size will fit in a single byte. If the check fails, the encoder throws an error suggesting increasing the slice scalar.