### PR TITLE
Removes erroneous references to RGB chromaFormat

### DIFF
--- a/src/DecodeHQ/DecodeHQ.cpp
+++ b/src/DecodeHQ/DecodeHQ.cpp
@@ -20,7 +20,7 @@ Its primary output is the decoded image sequence. However it may produce alterna
   3 the quantisation indices used for each slice\n\
   4 the decoded sequence\n\
 Input is just a sequence of compressed bytes.\n\
-Output (where appropriate) are in planar format (4:4:4, 4:2:2, 4:2:0 or RGB).\n\
+Output (where appropriate) are in planar format (4:4:4, 4:2:2, 4:2:0).\n\
 There can be 1 to 4 bytes per sample and the data is left (MSB) justified.\n\
 Data is assumed offset binary (which is fine for both YCbCr or RGB).\n\
 \n\

--- a/src/DecodeHQ/DecodeParams.cpp
+++ b/src/DecodeHQ/DecodeParams.cpp
@@ -114,8 +114,6 @@ ProgramParams getCommandLineParams(int argc, char * argv[], const char* details[
     const int slicePrefix = cla_slicePrefix.getValue();
 
     // Check for valid combinations of parameters and options
-    if ((chromaFormat==RGB) && (cla_lumaDepth.isSet() || cla_chromaDepth.isSet()))
-      throw invalid_argument("luma/chroma depth is not appropriate for RGB (use -z or --bitDepth)");
     if (cla_bitDepth.isSet() && (cla_lumaDepth.isSet() || cla_chromaDepth.isSet()))
       throw invalid_argument("bitDepth is incompatible with luma depth (and/or chroma depth): use one or the other");
     if (cla_progressive.isSet() && cla_interlace.isSet())

--- a/src/DecodeLD/DecodeLD.cpp
+++ b/src/DecodeLD/DecodeLD.cpp
@@ -21,7 +21,7 @@ Its primary output is the decoded image sequence. However it may produce alterna
   3 the quantisation indices used for each slice\n\
   4 the decoded sequence\n\
 Input is just a sequence of compressed bytes.\n\
-Output (where appropriate) are in planar format (4:4:4, 4:2:2, 4:2:0 or RGB).\n\
+Output (where appropriate) are in planar format (4:4:4, 4:2:2, 4:2:0).\n\
 There can be 1 to 4 bytes per sample and the data is left (MSB) justified.\n\
 Data is assumed offset binary (which is fine for both YCbCr or RGB).\n\
 \n\

--- a/src/DecodeLD/DecodeParams.cpp
+++ b/src/DecodeLD/DecodeParams.cpp
@@ -112,8 +112,6 @@ ProgramParams getCommandLineParams(int argc, char * argv[], const char* details[
     const Output output = cla_output.getValue();
 
     // Check for valid combinations of parameters and options
-    if ((chromaFormat==RGB) && (cla_lumaDepth.isSet() || cla_chromaDepth.isSet()))
-      throw invalid_argument("luma/chroma depth is not appropriate for RGB (use -z or --bitDepth)");
     if (cla_bitDepth.isSet() && (cla_lumaDepth.isSet() || cla_chromaDepth.isSet()))
       throw invalid_argument("bitDepth is incompatible with luma depth (and/or chroma depth): use one or the other");
     if (cla_progressive.isSet() && cla_interlace.isSet())

--- a/src/DecodeStream/DecodeStream.cpp
+++ b/src/DecodeStream/DecodeStream.cpp
@@ -20,7 +20,7 @@ Its primary output is the decoded image sequence. However it may produce alterna
   3 the quantisation indices used for each slice\n\
   4 the decoded sequence\n\
 Input is a VC-2 stream.\n\
-Output (where appropriate) are in planar format (4:4:4, 4:2:2, 4:2:0 or RGB).\n\
+Output (where appropriate) are in planar format (4:4:4, 4:2:2, 4:2:0).\n\
 There can be 1 to 4 bytes per sample and the data is left (MSB) justified.\n\
 Data is assumed offset binary (which is fine for both YCbCr or RGB).\n\
 \n\

--- a/src/EncodeHQ-CBR/EncodeHQ-CBR.cpp
+++ b/src/EncodeHQ-CBR/EncodeHQ-CBR.cpp
@@ -24,7 +24,7 @@ Its primary output is the compressed bytes. However it may produce alternative o
   5 VC2 bitstream (default output)\n\
   6 the decoded sequence\n\
   7 the PSNR for each frame\n\
-Input and output (where appropriate) are in planar format (4:4:4, 4:2:2, 4:2:0 or RGB).\n\
+Input and output (where appropriate) are in planar format (4:4:4, 4:2:2, 4:2:0).\n\
 There can be 1 to 4 bytes per sample and the data is left (MSB) justified.\n\
 Data is assumed offset binary (which is fine for both YCbCr or RGB).\n\
 \n\

--- a/src/EncodeHQ-ConstQ/EncodeHQ-ConstQ.cpp
+++ b/src/EncodeHQ-ConstQ/EncodeHQ-ConstQ.cpp
@@ -27,7 +27,7 @@ The primary output is the compressed bytes. However it may produce alternative o
   5 VC2 bitstream (default output)\n\
   6 the decoded sequence\n\
   7 the PSNR for each frame\n\
-Input and output (where appropriate) are in planar format (4:4:4, 4:2:2, 4:2:0 or RGB).\n\
+Input and output (where appropriate) are in planar format (4:4:4, 4:2:2, 4:2:0).\n\
 There can be 1 to 4 bytes per sample and the data is left (MSB) justified.\n\
 Data is assumed offset binary (which is fine for both YCbCr or RGB).\n\
 \n\

--- a/src/EncodeHQ-ConstQ/EncodeParams.cpp
+++ b/src/EncodeHQ-ConstQ/EncodeParams.cpp
@@ -89,7 +89,7 @@ ProgramParams getCommandLineParams(int argc, char * argv[], const char * details
     ValueArg<int> cla_lumaDepth("l", "lumaDepth", "Bit depth for luma (defaults to bits per input sample), for RGB use -z", false, 0, "integer", cmd);
     ValueArg<int> cla_bitDepth("z", "bitDepth", "Common bit depth for all components (defaults to bits per input sample)", false, 0, "integer", cmd);
     ValueArg<int> cla_bytes("n", "bytes", "Number of bytes per sample in image file (default 2)", false, 2, "integer", cmd);
-    ValueArg<ColourFormat> cla_format("f", "format", "Colour format (4:4:4, 4:2:2, 4:2:0 or RGB)", true, CF_UNSET, "string", cmd);
+    ValueArg<ColourFormat> cla_format("f", "format", "Colour format (4:4:4, 4:2:2, 4:2:0)", true, CF_UNSET, "string", cmd);
     ValueArg<int> cla_width("x", "width", "Picture width", true, 0, "integer", cmd);
     ValueArg<int> cla_height("y", "height", "Picture height", true, 0, "integer", cmd);
     ValueArg<int> cla_framerate("r", "framerate", "Frame Rate ( 1 = 24/1.001, 2 = 24, 3 = 25, 4 = 30/1.001, 5 = 30, 6 = 50, 7 = 60/1.001, 8 = 60, 9 = 15/1.001, 10 = 25/2, 11 = 48, 12=48/1.001, 13=96, 14=100, 15=120/1.001, 16=120(default 3)", false, 3, "integer", cmd);

--- a/src/EncodeLD/EncodeLD.cpp
+++ b/src/EncodeLD/EncodeLD.cpp
@@ -24,7 +24,7 @@ Its primary output is the VC-2 stream. However it may produce alternative output
   5 VC2 bitstream (default output)\n\
   6 the decoded sequence\n\
   7 the PSNR for each frame\n\
-Input and output (where appropriate) are in planar format (4:4:4, 4:2:2, 4:2:0 or RGB).\n\
+Input and output (where appropriate) are in planar format (4:4:4, 4:2:2, 4:2:0).\n\
 There can be 1 to 4 bytes per sample and the data is left (MSB) justified.\n\
 Data is assumed offset binary (which is fine for both YCbCr or RGB).\n\
 \n\

--- a/src/EncodeLD/EncodeParams.cpp
+++ b/src/EncodeLD/EncodeParams.cpp
@@ -90,7 +90,7 @@ ProgramParams getCommandLineParams(int argc, char * argv[], const char * details
     ValueArg<int> cla_lumaDepth("l", "lumaDepth", "Bit depth for luma (defaults to bits per input sample), for RGB use -z", false, 0, "integer", cmd);
     ValueArg<int> cla_bitDepth("z", "bitDepth", "Common bit depth for all components (defaults to bits per input sample)", false, 0, "integer", cmd);
     ValueArg<int> cla_bytes("n", "bytes", "Number of bytes per sample in image file (default 2)", false, 2, "integer", cmd);
-    ValueArg<ColourFormat> cla_format("f", "format", "Colour format (4:4:4, 4:2:2, 4:2:0 or RGB)", true, CF_UNSET, "string", cmd);
+    ValueArg<ColourFormat> cla_format("f", "format", "Colour format (4:4:4, 4:2:2, 4:2:0)", true, CF_UNSET, "string", cmd);
     ValueArg<int> cla_width("x", "width", "Picture width", true, 0, "integer", cmd);
     ValueArg<int> cla_height("y", "height", "Picture height", true, 0, "integer", cmd);
     ValueArg<int> cla_framerate("r", "framerate", "Frame Rate ( 1 = 24/1.001, 2 = 24, 3 = 25, 4 = 30/1.001, 5 = 30, 6 = 50, 7 = 60/1.001, 8 = 60, 9 = 15/1.001, 10 = 25/2, 11 = 48 (default 3)", false, 3, "integer", cmd);


### PR DESCRIPTION
I missed a couple of references to an unused variable 'RGB'. This removes them, and a few other references in help text.