### PR TITLE
Adds mode check when writing sequence header

### DIFF
--- a/src/EncodeStream/EncodeStream.cpp
+++ b/src/EncodeStream/EncodeStream.cpp
@@ -420,7 +420,11 @@ try { //Giant try block around all code to get error messages
     outStream << dataunitio::start_sequence;
     if ((mode == HQ_CBR || mode == LD) && fragmentLength > 0)
       outStream << dataunitio::fragmentedPictures(fragmentLength);
-    outStream << SequenceHeader(PROFILE_HQ, format.lumaHeight(), format.lumaWidth(), format.chromaFormat(), interlaced, frame_rate, topFieldFirst, lumaDepth);
+    if (mode == HQ_CBR || mode == HQ_ConstQ){
+      outStream << SequenceHeader(PROFILE_HQ, format.lumaHeight(), format.lumaWidth(), format.chromaFormat(), interlaced, frame_rate, topFieldFirst, lumaDepth);
+    } else if (mode == LD){
+      outStream << SequenceHeader(PROFILE_LD, format.lumaHeight(), format.lumaWidth(), format.chromaFormat(), interlaced, frame_rate, topFieldFirst, lumaDepth);
+    }
   }
   while (true) {
 


### PR DESCRIPTION
The previous commit added the EncodeStream utility, which missed a mode check when writing the sequence header. This lack of check meant that when the obsolete LD mode was selected the Sequence Header would indicate HQ operation leading to a non-conformant bitstream