### PR TITLE
42 Use DC Subband Prediction for LD mode

### DIFF
--- a/src/EncodeStream/EncodeStream.cpp
+++ b/src/EncodeStream/EncodeStream.cpp
@@ -516,8 +516,17 @@ try { //Giant try block around all code to get error messages
       }
 
       if (verbose) clog << "Quantise transform coefficients" << endl;
-      const Picture quantisedSlices = quantise_transform_np(transform, qIndices, qMatrix);
-      
+
+      // Use LL (DC) subband prediction for LD mode only
+      Picture quantSlices;
+      if (mode == LD){
+        quantSlices = quantise_transform(transform, qIndices, qMatrix);
+      }
+      else{
+        quantSlices = quantise_transform_np(transform, qIndices, qMatrix);
+      }
+      const Picture quantisedSlices = quantSlices;
+
       if (output==QUANTISED) {
         //Write quantised transform output as 4 byte 2's comp values
         clog << "Writing quantised transform coefficients to output file" << endl;

--- a/src/Library/src/Slices.cpp
+++ b/src/Library/src/Slices.cpp
@@ -205,6 +205,11 @@ namespace {
     const int yBits = luma_slice_bits(s.yuvSlice.y(), s.waveletDepth);
     const int uvSplitBits = utils::intlog2(8*sliceSize-7);
     const int uvBits = 8*sliceSize - 7 - uvSplitBits - yBits;
+    
+    if (uvBits < chroma_slice_bits(s.yuvSlice.c1(), s.yuvSlice.c2(), s.waveletDepth) ) {
+      throw std::logic_error("SliceIO, LD mode: Too many bytes for the U and V slices");
+    }
+
     stream << Bits(uvSplitBits, yBits);
 
     const int numberOfSubbands = 3*s.waveletDepth+1;


### PR DESCRIPTION
Closes #42 

When combining tools in #40 the LD mode quantizer was errroneously set to not use DC subband prediction. The determination of quantization indices for the LD mode did use DC subband prediction. This mismatch led to write errors when too few bytes were allocated to the output bitstream.

This pull request adds a more specific error message to help locate future problems and fixes the bug by using DC subband prediction for the LD mode.